### PR TITLE
CdTe detector response can now be downloaded

### DIFF
--- a/response_tools/detector_response.py
+++ b/response_tools/detector_response.py
@@ -1,4 +1,4 @@
-"""Code to load different detectro responses. """
+"""Code to load different detector responses. """
 
 from dataclasses import dataclass
 

--- a/response_tools/detector_response.py
+++ b/response_tools/detector_response.py
@@ -16,7 +16,6 @@ from response_tools.util import BaseOutput
 
 FILE_PATH = response_tools.responseFilePath
 RESPONSE_INFO_TYPE = response_tools.contextResponseInfo["files"]["detectors"]
-DET_RESP_PATH = os.path.join(pathlib.Path(__file__).parent, "response-information", "detector-response-data")
 ASSETS_PATH = os.path.join(pathlib.Path(__file__).parent, "..", "assets", "response-tools-figs", "det-resp-figs")
 
 @dataclass
@@ -152,7 +151,9 @@ def cdte_det_resp(cdte:int=None, region:int=None, pitch=None, side:str="merged",
     
     region = pitch2region[pitch] if have_pitch else region
     
-    _f = os.path.join(DET_RESP_PATH, "cdte", side, f"Resp_3keVto30keV_CdTe{cdte}_reg{region}_{event_type}.rmf") if file is None else file
+    _f = os.path.join(FILE_PATH, 
+                      RESPONSE_INFO_TYPE[f"cdte_det_{side}_resp"], 
+                      f"Resp_3keVto30keV_CdTe{cdte}_reg{region}_{event_type}.rmf") if file is None else file
     r = cdte_det_resp_rmf(_f)
     r.update_function_path(sys._getframe().f_code.co_name)
     r.detector = f"CdTe{cdte}-Detector-Response"
@@ -434,7 +435,7 @@ def asset_cmos_resp(save_asset=False):
 
 def asset_cdte_resp(save_asset=False):
     # CdTe
-    d_rmf = os.path.join(DET_RESP_PATH, "cdte", "pt") 
+    d_rmf = os.path.join(FILE_PATH, RESPONSE_INFO_TYPE[f"cdte_det_pt_resp"])
     f_rmf = "Resp_3keVto30keV_CdTe1_reg0_1hit.rmf"
 
     cdte_resp = cdte_det_resp_rmf(os.path.join(pathlib.Path(__file__).parent, d_rmf, f_rmf))

--- a/response_tools/response-information/info.yaml
+++ b/response_tools/response-information/info.yaml
@@ -19,6 +19,8 @@ files:
   detectors:
     cmos_det_telescope-0_resp: "detector-response-data/cmos/foxsi4_telescope-0_BASIC_RESPONSE_MATRIX_v1.fits"
     cmos_det_telescope-1_resp: "detector-response-data/cmos/foxsi4_telescope-1_BASIC_RESPONSE_MATRIX_v1.fits"
+    cdte_det_merged_resp: "detector-response-data/cdte/merged_v1/"
+    cdte_det_pt_resp: "detector-response-data/cdte/pt_v1/"
 
   attenuation:
     att_thermal_blanket: "attenuation-data/F4_Blanket_transmission_v1.dat"

--- a/response_tools/telescope_parts.py
+++ b/response_tools/telescope_parts.py
@@ -608,7 +608,7 @@ def foxsi4_position5_detector_response(region:int=None, pitch=None, _side:str="m
 if __name__=="__main__":
     # mid_energies = [4.5,  5.5,  6.5,  7.5,  8.5,  9.5, 11. , 13. , 15. , 17. , 19. , 22.5, 27.5] << u.keV
     # p2_tb = position2_thermal_blanket(mid_energies)
-    p2_dr_reg = position2_detector_response(region=0)
-    p2_dr_pitch = position2_detector_response(pitch=60<<u.um)
-    position2_detector_response(region=0, pitch=60<<u.um)
-    position2_detector_response(pitch=80<<u.um, _side="merged", _event_type="1hit")
+    p2_dr_reg = foxsi4_position2_detector_response(region=0)
+    p2_dr_pitch = foxsi4_position2_detector_response(pitch=60<<u.um)
+    foxsi4_position2_detector_response(region=0, pitch=60<<u.um)
+    foxsi4_position2_detector_response(pitch=80<<u.um, _side="merged", _event_type="1hit")

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setuptools.setup(
             "pytest",
             "pandas",
             "beautifulsoup4",
-            "inquirer"
+            "inquirer",
+            "tqdm",
+            "requests",
         ],
     packages=setuptools.find_packages(),
     zip_safe=False,


### PR DESCRIPTION
Downloader can now download contents of folders. Detector responses for CdTe are now downloaded.

This PR adds in the ability for the downloader to know if the URL given is for a folder (just has to end in a "/"). This means the CdTe detector responses can be downloaded like the other files. The CdTe response loader no longer has file paths hard-coded and will look to the YAML for the correct, _versioned_ path.